### PR TITLE
feat(compute): add compute entity and parsl factory

### DIFF
--- a/paropt/runner/parsl/__init__.py
+++ b/paropt/runner/parsl/__init__.py
@@ -1,5 +1,5 @@
 from .parsl_runner import ParslRunner
-from .config import local_config
+from .config import parslConfigFromCompute
 from .lib import timeCmd
 
 __all__ = [

--- a/paropt/runner/parsl/config.py
+++ b/paropt/runner/parsl/config.py
@@ -27,8 +27,8 @@ def parslConfigFromCompute(compute):
       public_ip = getAWSPublicIP()
 
       # get the required environment variables
-      required_env_vars = ["PAROPT_AWS_REGION", "PAROPT_AWS_KEY_NAME", "PAROPT_AWS_STATE_FILE_PATH"]
-      env_vars = {varname: os.getenv(varname) for varname in required_env_vars}
+      required_env_vars = ["PAROPT_AWS_REGION", "PAROPT_AWS_KEY_NAME", "PAROPT_AWS_STATE_FILE"]
+      env_vars = {varname.replace('PAROPT_AWS_', '').lower(): os.getenv(varname) for varname in required_env_vars}
       missing_vars = [varname for varname, value in env_vars.items() if value == None]
       if missing_vars:
         raise Exception("Missing required environment variables for running parsl with AWS:\n{}".format(missing_vars))

--- a/paropt/runner/parsl/config.py
+++ b/paropt/runner/parsl/config.py
@@ -3,6 +3,7 @@ from socket import timeout
 import urllib
 from urllib.error import HTTPError, URLError
 import logging
+import configparser
 
 from parsl.config import Config
 from parsl.executors import ThreadPoolExecutor, HighThroughputExecutor

--- a/paropt/runner/parsl/config.py
+++ b/paropt/runner/parsl/config.py
@@ -1,11 +1,74 @@
-from parsl.config import Config
-from parsl.executors import ThreadPoolExecutor
+from socket import timeout
+import urllib
+from urllib.error import HTTPError, URLError
+import logging
 
-local_config = Config(
-  executors=[
-    ThreadPoolExecutor(
-      max_threads=8,
-      label='local_threads'
+from parsl.config import Config
+from parsl.executors import ThreadPoolExecutor, HighThroughputExecutor
+from parsl.providers import AWSProvider
+
+from paropt.storage.entities import EC2Compute, LocalCompute
+
+logger = logging.getLogger(__name__)
+
+def parslConfigFromCompute(compute):
+  """Given a Compute instance, return a setup parsl configuration
+  NOTE: Assumes the paropt is being run on an EC2 instance with access to metadata service
+  """
+  if isinstance(compute, EC2Compute):
+    try:
+      public_ip = urllib.request.urlopen(
+        url="http://169.254.169.254/latest/meta-data/public-ipv4",
+        timeout=5
+      ).read().decode()
+
+      paropt_config_path = os.path.expanduser('~/.paropt/config')
+      paropt_config = configparser.ConfigParser()
+      paropt_config.read(paropt_config_path)
+
+      parsl_config = Config(
+        executors=[
+          HighThroughputExecutor(
+            label='htex_local',
+            address=public_ip,
+            worker_port_range=(54000, 54050),
+            interchange_port_range=(54051, 54100),
+            cores_per_worker=1,
+            max_workers=1,
+            provider=AWSProvider(
+              image_id=compute.ami,
+              worker_init='pip3 install git+https://git@github.com/macintoshpie/paropt',
+              region=paropt_config['aws']['region'],
+              key_name=paropt_config['aws']['key_name'],
+              state_file=paropt_config['aws']['state_file'],
+              nodes_per_block=1,
+              init_blocks=1,
+              max_blocks=1,
+              min_blocks=0,
+              walltime='01:00:00',
+            ),
+          )
+        ],
+        strategy=None,
+      )
+
+      return parsl_config
+    except KeyError as e:
+      logger.error('Failed initializing aws config: {}'.format(e))
+      raise e
+    except (HTTPError, URLError, OSError) as e:
+      logger.error('Request to metadata service failed: {}'.format(e))
+      raise e
+
+  elif isinstance(compute, LocalCompute):
+    return Config(
+      executors=[
+        ThreadPoolExecutor(
+          max_threads=8,
+          label='local_threads'
+        )
+      ]
     )
-  ]
-)
+  
+  else:
+    raise Exception('Unknown Compute type')

--- a/paropt/runner/parsl/config.py
+++ b/paropt/runner/parsl/config.py
@@ -1,3 +1,4 @@
+import os
 from socket import timeout
 import urllib
 from urllib.error import HTTPError, URLError

--- a/paropt/runner/parsl/parsl_runner.py
+++ b/paropt/runner/parsl/parsl_runner.py
@@ -9,24 +9,27 @@ import parsl
 from paropt import setFileLogger
 from paropt.storage import LocalFile
 from paropt.storage.entities import Trial, ParameterConfig
+from paropt.runner.parsl.config import parslConfigFromCompute
 
 logger = logging.getLogger(__name__)
 
 class ParslRunner:
   def __init__(self,
-              parsl_config,
+              compute,
               parsl_app,
               optimizer,
               storage=None,
               experiment=None,
               logs_root_dir='.'):
 
-    self.parsl_config = parsl_config
     self.parsl_app = parsl_app
     self._dfk = None
     self.optimizer = optimizer
     self.storage = storage if storage != None else LocalFile()
     self.session = storage.Session()
+
+    self.compute, _ = storage.getOrCreateCompute(self.session, compute)
+    self.parsl_config = parslConfigFromCompute(compute)
 
     self.experiment, last_run_number, _ = storage.getOrCreateExperiment(self.session, experiment)
     self.run_number = last_run_number + 1
@@ -35,21 +38,30 @@ class ParslRunner:
 
     # setup paropt info directories
     self.paropt_dir = f'{logs_root_dir}/optinfo'
-    if not os.path.exists(self.paropt_dir):
-      os.mkdir(self.paropt_dir)
+    if not os.path.exists(logs_root_dir):
+      raise Exception(f'Logs directory does not exist: {logs_root_dir}')
+    os.makedirs(self.paropt_dir, exist_ok=True)
+    
+    # setup directory and files for this run
+    self.exp_run_dir = f'{self.paropt_dir}/exp_{self.experiment.id:03}/{self.run_number:03}'
+    os.makedirs(self.exp_run_dir, exist_ok=True)
+    setFileLogger(f'{self.exp_run_dir}/paropt.log')
+    self.templated_scripts_dir = f'{self.exp_run_dir}/templated_scripts'
 
-    self.run_dir = f'{self.paropt_dir}/exp_{self.experiment.id:03}/{self.run_number:03}'
-    if os.path.exists(self.run_dir):
-      raise Exception(f'{self.run_dir} already exists, '
-                       'cannot continue with inconsistency between database and local run info')
-    os.makedirs(self.run_dir)
     # set parsl's logging directory
-    self.parsl_config.run_dir = f'{self.run_dir}/parsl'
-
-    self.templated_scripts_dir = f'{self.run_dir}/templated_scripts'
-    os.mkdir(self.templated_scripts_dir)
-
-    setFileLogger(f'{self.run_dir}/paropt.log')
+    self.parsl_config.run_dir = f'{self.exp_run_dir}/parsl'
+    os.makedirs(self.templated_scripts_dir, exist_ok=True)
+  
+  def __repr__(self):
+    return '\n'.join([
+      f'ParslRunner(',
+      f'  compute={self.compute!r}',
+      f'  parsl_app={self.parsl_app!r}',
+      f'  optimizer={self.optimizer!r}',
+      f'  storage={self.storage!r}',
+      f'  experiment={self.experiment!r}',
+      f')\n'
+    ])
 
   def _validateResult(self, params, res):
     if res[0] != 0:
@@ -72,14 +84,11 @@ class ParslRunner:
     if debug:
       parsl.set_stream_logger()
     self._dfk = parsl.load(self.parsl_config)
+    logger.info(f'Starting ParslRunner with config\n{self}')
     try:
       for parameter_configs in self.optimizer:
         logger.info(f'Writing script with configs {parameter_configs}')
         script_path, script_content = self._writeScript(parameter_configs)
-        # TODO: add user hook for customization
-        # Hook should take in tool param configuration and current parsl configuration as arguments
-        # Hook should return a new parsl configuration if it needs to be changed, or None if not
-        # self.prerun_hook(config, self.parsl_config)
         logger.info(f'Starting trial with script at {script_path}')
         result = self.parsl_app(script_content).result()
         self._validateResult(parameter_configs, result)
@@ -87,14 +96,15 @@ class ParslRunner:
           outcome=result[2],
           parameter_configs=parameter_configs,
           run_number=self.run_number,
-          experiment_id=self.experiment.id
+          experiment_id=self.experiment.id,
+          compute_id=self.compute.id
         )
         self.storage.saveResult(self.session, trial)
         self.optimizer.register(trial)
     except Exception as e:
       logger.info('Whoops, something went wrong... {e}')
       logger.exception(traceback.format_exc())
-    logger.info('Finished running tasks')
+    logger.info('Finished running tasks\n\n\n')
   
   def cleanup(self):
     """Cleanup DFK and parsl"""

--- a/paropt/storage/entities/__init__.py
+++ b/paropt/storage/entities/__init__.py
@@ -2,6 +2,7 @@ from .experiment import Experiment
 from .parameter import Parameter
 from .parameter_config import ParameterConfig
 from .trial import Trial
+from .compute import Compute, EC2Compute, LocalCompute
 
 __all__ = [
   'Experiment',

--- a/paropt/storage/entities/compute.py
+++ b/paropt/storage/entities/compute.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, Integer, Float, String, ForeignKey
+from sqlalchemy.orm import relationship, backref
+
+from .orm_base import ORMBase
+
+class Compute(ORMBase):
+  __tablename__ = 'computes'
+
+  id = Column(Integer, primary_key=True)
+  type = Column(String(20))
+  trials = relationship("Trial")
+
+  __mapper_args__ = {
+    'polymorphic_on': type,
+    'polymorphic_identity': 'compute'
+  }
+
+class EC2Compute(Compute):
+  instance_family = Column(String(10))
+  instance_model = Column(String(20))
+  ami = Column(String(50))
+
+  __mapper_args__ = {'polymorphic_identity': 'ec2'}
+
+  def __repr__(self):
+    return (
+      f'EC2Compute('
+      f'instance_family={self.instance_family}'
+      f'instance_model={self.instance_model}'
+      f'ami={self.ami}'
+      f')'
+    )
+
+class LocalCompute(Compute):
+  max_threads = Column(Integer)
+
+  __mapper_args__ = {'polymorphic_identity': 'local'}
+
+  def __repr__(self):
+    return (
+      f'LocalCompute('
+      f'max_threads={self.max_threads}'
+      f')'
+    )

--- a/paropt/storage/entities/compute.py
+++ b/paropt/storage/entities/compute.py
@@ -8,7 +8,7 @@ class Compute(ORMBase):
 
   id = Column(Integer, primary_key=True)
   type = Column(String(20))
-  trials = relationship("Trial")
+  experiments = relationship("Experiment")
 
   __mapper_args__ = {
     'polymorphic_on': type,

--- a/paropt/storage/entities/compute.py
+++ b/paropt/storage/entities/compute.py
@@ -8,7 +8,7 @@ class Compute(ORMBase):
 
   id = Column(Integer, primary_key=True)
   type = Column(String(20))
-  experiments = relationship("Experiment")
+  experiments = relationship("Experiment", lazy=False)
 
   __mapper_args__ = {
     'polymorphic_on': type,

--- a/paropt/storage/entities/compute.py
+++ b/paropt/storage/entities/compute.py
@@ -30,6 +30,14 @@ class EC2Compute(Compute):
       f'ami={self.ami}'
       f')'
     )
+  
+  def asdict(self):
+    return {
+      'type': self.type,
+      'instance_family': self.instance_family,
+      'instance_model': self.instance_model,
+      'ami': self.ami
+    }
 
 class LocalCompute(Compute):
   max_threads = Column(Integer)
@@ -42,3 +50,9 @@ class LocalCompute(Compute):
       f'max_threads={self.max_threads}'
       f')'
     )
+  
+  def asdict(self):
+    return {
+      'type': self.type,
+      'max_threads': self.max_threads
+    }

--- a/paropt/storage/entities/experiment.py
+++ b/paropt/storage/entities/experiment.py
@@ -12,6 +12,8 @@ class Experiment(ORMBase):
   command_template_string = Column(String, nullable=False)
   parameters = relationship("Parameter", lazy=False)
   trials = relationship("Trial")
+  compute_id = Column(Integer, ForeignKey('computes.id'))
+  compute = relationship("Compute")
 
   def __repr__(self):
     return (
@@ -19,7 +21,8 @@ class Experiment(ORMBase):
       f'id={self.id}, '
       f'tool_name={self.tool_name}, '
       f'parameters={self.parameters}, '
-      f'command_template_string={self.command_template_string})'
+      f'command_template_string={self.command_template_string}), '
+      f'compute={self.compute!r}'
     )
   
   def asdict(self):

--- a/paropt/storage/entities/experiment.py
+++ b/paropt/storage/entities/experiment.py
@@ -46,7 +46,6 @@ class Experiment(ORMBase):
     return self.hash
 
 def set_hash(mapper, connect, target):
-  print("CALLED THE INSERT THING")
   target.setHash()
 
 listen(Experiment, 'before_insert', set_hash)

--- a/paropt/storage/entities/experiment.py
+++ b/paropt/storage/entities/experiment.py
@@ -34,7 +34,8 @@ class Experiment(ORMBase):
       'id': self.id,
       'tool_name': self.tool_name, 
       'parameters': [parameter.asdict() for parameter in self.parameters],
-      'command_template_string': self.command_template_string
+      'command_template_string': self.command_template_string,
+      'compute': self.compute.asdict()
     }
   
   def getHash(self):

--- a/paropt/storage/entities/experiment.py
+++ b/paropt/storage/entities/experiment.py
@@ -13,7 +13,7 @@ class Experiment(ORMBase):
   parameters = relationship("Parameter", lazy=False)
   trials = relationship("Trial")
   compute_id = Column(Integer, ForeignKey('computes.id'))
-  compute = relationship("Compute", lazy='joined')
+  compute = relationship("Compute", lazy=False)
 
   def __repr__(self):
     return (

--- a/paropt/storage/entities/experiment.py
+++ b/paropt/storage/entities/experiment.py
@@ -13,7 +13,7 @@ class Experiment(ORMBase):
   parameters = relationship("Parameter", lazy=False)
   trials = relationship("Trial")
   compute_id = Column(Integer, ForeignKey('computes.id'))
-  compute = relationship("Compute")
+  compute = relationship("Compute", lazy='joined')
 
   def __repr__(self):
     return (

--- a/paropt/storage/entities/trial.py
+++ b/paropt/storage/entities/trial.py
@@ -13,7 +13,8 @@ class Trial(ORMBase):
   experiment_id = Column(Integer, ForeignKey('experiments.id'), nullable=False)
   run_number = Column(Integer, nullable=False)
   outcome = Column(Float, nullable=False)
-  parameter_configs = relationship("ParameterConfig")
+  parameter_configs = relationship('ParameterConfig')
+  compute_id = Column(Integer, ForeignKey('computes.id'))
   timestamp = Column(TIMESTAMP, server_default=func.now(), onupdate=func.current_timestamp())
 
   def __repr__(self):

--- a/paropt/storage/entities/trial.py
+++ b/paropt/storage/entities/trial.py
@@ -14,7 +14,6 @@ class Trial(ORMBase):
   run_number = Column(Integer, nullable=False)
   outcome = Column(Float, nullable=False)
   parameter_configs = relationship('ParameterConfig')
-  compute_id = Column(Integer, ForeignKey('computes.id'))
   timestamp = Column(TIMESTAMP, server_default=func.now(), onupdate=func.current_timestamp())
 
   def __repr__(self):

--- a/paropt/storage/relational_db.py
+++ b/paropt/storage/relational_db.py
@@ -8,10 +8,8 @@ from sqlalchemy.sql.expression import func
 
 from .entities.orm_base import create_all
 from .storage_base import StorageBase
-from .entities.trial import Trial
-from .entities.parameter_config import ParameterConfig
-from .entities.parameter import Parameter
-from .entities.experiment import Experiment
+from .entities import (Trial, Parameter, Experiment, ParameterConfig,
+  Compute, EC2Compute, LocalCompute)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +77,10 @@ class RelationalDB(StorageBase):
     
     return all_results
   
+  def _assertIsInstanceOf(self, instance, clss):
+    if not isinstance(instance, clss):
+      raise Exception(f'Provided instance must be of type {clss.__name__}')
+
   def getExperiment(self, session, experiment_id):
     if not self.initialized:
       self._setup()
@@ -93,10 +95,8 @@ class RelationalDB(StorageBase):
     if not self.initialized:
       self._setup()
 
-    if not isinstance(experiment, Experiment):
-      raise Exception('Provided experiment must be instance of Experiment')
+    self._assertIsInstanceOf(experiment, Experiment)
     
-    # session = self.Session()
     # Assuming experiments are unique on these properties
     # TODO: improve this by hashing some vals for id or make this assertion in orm
     instance = session.query(Experiment) \
@@ -117,3 +117,32 @@ class RelationalDB(StorageBase):
         raise
       last_run_number = self.getLastRunNumber(session, experiment.id)
       return experiment, last_run_number, True
+  
+  def getOrCreateCompute(self, session, compute):
+    if not self.initialized:
+      self._setup()
+
+    self._assertIsInstanceOf(compute, Compute)
+    if isinstance(compute, EC2Compute):
+      foundCompute = session.query(EC2Compute) \
+        .filter(EC2Compute.instance_family == compute.instance_family) \
+        .filter(EC2Compute.instance_model == compute.instance_model) \
+        .filter(EC2Compute.ami == compute.ami) \
+        .first()
+    elif isinstance(compute, LocalCompute):
+      foundCompute = session.query(LocalCompute) \
+        .filter(LocalCompute.max_threads == compute.max_threads) \
+        .first()
+
+    if foundCompute:
+      return foundCompute, False
+    else:
+      # create compute
+      logger.info("Creating new compute:\n{}".format(compute))
+      session.add(compute)
+      try:
+        session.commit()
+      except:
+        session.rollback()
+        raise
+      return compute, True

--- a/paropt/storage/relational_db.py
+++ b/paropt/storage/relational_db.py
@@ -123,16 +123,18 @@ class RelationalDB(StorageBase):
       self._setup()
 
     self._assertIsInstanceOf(compute, Compute)
-    if isinstance(compute, EC2Compute):
+    if compute.type == "ec2":
       foundCompute = session.query(EC2Compute) \
         .filter(EC2Compute.instance_family == compute.instance_family) \
         .filter(EC2Compute.instance_model == compute.instance_model) \
         .filter(EC2Compute.ami == compute.ami) \
         .first()
-    elif isinstance(compute, LocalCompute):
+    elif compute.type == "local":
       foundCompute = session.query(LocalCompute) \
         .filter(LocalCompute.max_threads == compute.max_threads) \
         .first()
+    else:
+      raise Exception("Unrecognized type of compute: {}".format(compute))
 
     if foundCompute:
       return foundCompute, False

--- a/paropt/storage/relational_db.py
+++ b/paropt/storage/relational_db.py
@@ -99,11 +99,9 @@ class RelationalDB(StorageBase):
     
     # Assuming experiments are unique on these properties
     # TODO: improve this by hashing some vals for id or make this assertion in orm
-    experiment.compute, _ = self.getOrCreateCompute(session, experiment.compute)
+    hash_attr = experiment.getHash()
     instance = session.query(Experiment) \
-      .filter(Experiment.tool_name == experiment.tool_name) \
-      .filter(Experiment.command_template_string == experiment.command_template_string) \
-      .filter(Experiment.compute_id == experiment.compute.id) \
+      .filter(Experiment.hash == hash_attr) \
       .first()
     if instance:
       last_run_number = self.getLastRunNumber(session, instance.id)

--- a/paropt/storage/relational_db.py
+++ b/paropt/storage/relational_db.py
@@ -99,9 +99,11 @@ class RelationalDB(StorageBase):
     
     # Assuming experiments are unique on these properties
     # TODO: improve this by hashing some vals for id or make this assertion in orm
+    experiment.compute, _ = self.getOrCreateCompute(session, experiment.compute)
     instance = session.query(Experiment) \
       .filter(Experiment.tool_name == experiment.tool_name) \
       .filter(Experiment.command_template_string == experiment.command_template_string) \
+      .filter(Experiment.compute_id == experiment.compute.id) \
       .first()
     if instance:
       last_run_number = self.getLastRunNumber(session, instance.id)


### PR DESCRIPTION
New Features:
* Compute entity, with EC2Compute and LocalCompute subclasses
* parsl factory, where given a compute instance it returns a parsl configuration

Changes:
* now pass a compute object to ParslRunner for instantiation instead of a parsl configuration.
* Experiments are uniquely identified by a hash of their __repr__ string