### PR TITLE
chore(requirements): pin parsl to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bayesian-optimization==1.0.0
-parsl>=0.7.1
+parsl==0.8.0
 psycopg2==2.7.7
 sqlalchemy==1.3.3
 sqlalchemy-utils==0.33.11


### PR DESCRIPTION
## Changes
- pinned parsl to 0.8.0 in requirements (want to fix paropt-service and paropt parsl versions so it won't break every time parsl is updated)